### PR TITLE
Fix cookies not appearing in SFAuthenticationSession by setting them to expire

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Use SFAuthenticationSession to get cookies from Safari
 
 Example using iOS 11's [SFAuthenticationSession](https://developer.apple.com/documentation/safariservices/sfauthenticationsession) to get cookies from Safari. Contains a simple python Flask web service to create and return cookies and an iOS app that uses SFAuthenticationSession API to fetch cookies from the Flask app. Assumes you have some level of familiarity with Xcode and the command line, but does not require experience with python / Flask.
- 
-**Note:** *There appears to be [a bug with SFAuthenticationSession](https://twitter.com/rmondello/status/887434621989789696) that prevents this from working.* 
+
+**Note:** *There appears to be [a bug with SFAuthenticationSession](https://twitter.com/rmondello/status/887434621989789696) that prevents this from working for [cookies that are set with no expiry](https://stackoverflow.com/questions/46569570/sfauthenticationsession-isnt-sharing-cookies-on-the-real-devices) / with the lifetime of a session cookie, even if those sessions are still alive.*
 
 ## Running
 
-You will need to start the Flask server, and run the iOS app in the simulator using xcode 9 (beta). 
+You will need to start the Flask server, and run the iOS app in the simulator using xcode 9.
 
 ### Run the Server
 
@@ -29,18 +29,20 @@ Example using cookie "user" - replace with any cookie of your choice:
 /create-cookie/user - sets random cookie val for "user"
 /get-cookie/user - gets cookie val for "user" with optional query param "callbackUrl" to be redirected to with cookie appended as query param
 /delete-cookie/user - expires cookie for "user"
+
+Current cookies set are:
+
 ```
 
-You can click around to test the endpoints. Navigating to `/create-cookie/user` creates a cookie for the key `user`, but you could use any key you want, for example `/create-cookie/sessionID` to create a random cookie value for the key `sessionID`. 
- 
+You can click around to test the endpoints. Navigating to `/create-cookie/user` creates a cookie for the key `user`, but you could use any key you want, for example `/create-cookie/sessionID` to create a random cookie value for the key `sessionID`.
+
 ### Run the App
 
-Xcode 9 and iOS 11 are required to run the app. To attempt fetching cookies from Safari, do the following: 
+Xcode 9 and iOS 11 are required to run the app. To attempt fetching cookies from Safari, do the following:
 
-1. Run the app in a device simulator. 
-2. From the simulator exit the app by pressing the home button and go to safari. 
-3. Go to http://0.0.0.0:5000/create-cookie/user to create a cookie for the key "user".
-4. Go back to the app in the simulator and click the "Get cookie from Safari" button. 
+1. Run the app in a device simulator.
+2. From the simulator exit the app by pressing the home button and go to safari.
+3. Go to http://0.0.0.0:5000/create-cookie/expiry-fix-test to create a cookie for the key "expiry-fix-test". Update the value of `cookiename` to use a different key / value pair.
+4. Go back to the app in the simulator and click the "Get cookie from Safari" button.
 5. You will see a dialogue like the following: ![SFAuthenticationSession dialogue screenshot](screenshot.png)
-6. Click continue; a SafariViewController will be launched and then you should be redirected back into your app with the cookie for "user" shown in the app. 
-
+6. Click continue; a SafariViewController will be launched and then you should be redirected back into your app with the cookie for "expiry-fix-test" shown in the app.

--- a/SFAuthenticationSessionExample/SFAuthenticationSessionExample/ViewController.swift
+++ b/SFAuthenticationSessionExample/SFAuthenticationSessionExample/ViewController.swift
@@ -19,10 +19,12 @@ class ViewController: UIViewController {
     @IBOutlet weak var cookieLabel: UILabel!
     var authSession: SFAuthenticationSession?
 
+    let cookiename = "expiry-fix-test"
+
     @IBAction func getUserAuth(_ sender: Any) {
-        
+
         let callbackUrl  = "SFAuthenticationSessionExample://"
-        let authURL = "http://0.0.0.0:5000/get-cookie/user?callbackUrl=" + callbackUrl
+        let authURL = "http://0.0.0.0:5000/get-cookie/" + cookiename + "?callbackUrl=" + callbackUrl
         //Initialize auth session
         self.authSession = SFAuthenticationSession(url: URL(string: authURL)!, callbackURLScheme: callbackUrl, completionHandler: { (callBack:URL?, error:Error? ) in
             guard error == nil, let successURL = callBack else {
@@ -30,11 +32,10 @@ class ViewController: UIViewController {
                 self.cookieLabel.text = "Error retrieving cookie"
                 return
             }
-            let user = getQueryStringParameter(url: (successURL.absoluteString), param: "user")
-            self.cookieLabel.text = (user == "None") ? "user cookie not set" : "User: " + user!
+            let cookievalue = getQueryStringParameter(url: (successURL.absoluteString), param: self.cookiename)
+            self.cookieLabel.text = (cookievalue == "None") ? "cookie not set" : "Cookie for key " + self.cookiename + ": " + cookievalue!
         })
         cookieLabel.text = "Starting SFAuthenticationSession..."
         self.authSession?.start()
     }
 }
-


### PR DESCRIPTION
Super helpful example @dvdhpkns. Lots of my Googling on SFAuthenticationSessions led me here...

I was able to reproduce the bug you filed / the cookies not showing in-app, and got it working with some very minor changes. I also updated the Flask app to print all available cookies on any page load to help debug.

It appears session cookies (those set without an expires or max-age param) do not appear in SFAuthenticationSession sessions, even if the session is still active in Safari and the cookies are readable there. I don’t know if this is a bug or intentional from Apple 🤷‍♂️ . Setting an expiry time on the cookie via expires or max-age fixes the issue and the cookies are available in the SFAuthenticationSession session.